### PR TITLE
Update publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,9 +17,9 @@ permissions:
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
-
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
@@ -33,7 +33,4 @@ jobs:
     - name: Build package
       run: python -m build -s
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Uses trusted publishers instead of token

## PR summary

Allows using trusted publishers instead of token in publish.yml

## Todos

None

## Test plan

None

## Breaking changes

None

## Related Issues

None